### PR TITLE
Add ability to pass props

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
   "plugins": [
     "syntax-dynamic-import",
     [
+      "transform-object-rest-spread",
       "transform-react-remove-prop-types",
       {
         "mode": "wrap"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-eslint": "^8.0.3",
     "babel-jest": "^21.2.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.10",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",

--- a/src/buttons/facebook.js
+++ b/src/buttons/facebook.js
@@ -44,7 +44,7 @@ const Button = ({
     {simple || simpleReverse ? (
       <FacebookIconFill {...props} />
     ) : (
-      <Facebook small={small} solidcircle={solidcircle} {...props} >
+      <Facebook small={small} solidcircle={solidcircle} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/facebook.js
+++ b/src/buttons/facebook.js
@@ -30,7 +30,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.facebook(link)}
@@ -41,9 +42,9 @@ const Button = ({
     aria-label="Share on Facebook"
   >
     {simple || simpleReverse ? (
-      <FacebookIconFill />
+      <FacebookIconFill {...props} />
     ) : (
-      <Facebook small={small} solidcircle={solidcircle}>
+      <Facebook small={small} solidcircle={solidcircle} {...props} >
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/google.js
+++ b/src/buttons/google.js
@@ -40,7 +40,7 @@ const Button = ({
     {simple || simpleReverse ? (
       <GoogleIconFill {...props} />
     ) : (
-      <Google small={small} solidcircle={solidcircle} {...props} >
+      <Google small={small} solidcircle={solidcircle} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/google.js
+++ b/src/buttons/google.js
@@ -26,7 +26,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.google(link)}
@@ -37,9 +38,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <GoogleIconFill />
+      <GoogleIconFill {...props} />
     ) : (
-      <Google small={small} solidcircle={solidcircle}>
+      <Google small={small} solidcircle={solidcircle} {...props} >
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/hacker.js
+++ b/src/buttons/hacker.js
@@ -31,7 +31,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     simple={simple}
@@ -42,9 +43,9 @@ const Button = ({
     aria-label="Share on HackerNews"
   >
     {simple || simpleReverse ? (
-      <HackerIconFill />
+      <HackerIconFill {...props} />
     ) : (
-      <Hacker small={small}>
+      <Hacker small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/linkedin.js
+++ b/src/buttons/linkedin.js
@@ -31,7 +31,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.linkedin(message, link)}
@@ -42,9 +43,9 @@ const Button = ({
     aria-label="Share on Linkedin"
   >
     {simple || simpleReverse ? (
-      <LinkedinIconFill />
+      <LinkedinIconFill {...props} />
     ) : (
-      <Linkedin small={small}>
+      <Linkedin small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/mail.js
+++ b/src/buttons/mail.js
@@ -31,7 +31,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.mail(message, link)}
@@ -42,9 +43,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <EmailIconFill />
+      <EmailIconFill {...props} />
     ) : (
-      <Email small={small}>
+      <Email small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/pinterest.js
+++ b/src/buttons/pinterest.js
@@ -31,7 +31,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.pinterest(message, link)}
@@ -42,9 +43,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <PinterestIconFill />
+      <PinterestIconFill {...props} />
     ) : (
-      <Pinterest small={small}>
+      <Pinterest small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/reddit.js
+++ b/src/buttons/reddit.js
@@ -30,7 +30,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.reddit(link)}
@@ -41,9 +42,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <RedditIconFill />
+      <RedditIconFill {...props} />
     ) : (
-      <Reddit small={small}>
+      <Reddit small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/telegram.js
+++ b/src/buttons/telegram.js
@@ -31,7 +31,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.telegram(message, link)}
@@ -42,9 +43,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <TelegramIconFill />
+      <TelegramIconFill {...props} />
     ) : (
-      <Telegram small={small}>
+      <Telegram small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/tumblr.js
+++ b/src/buttons/tumblr.js
@@ -26,7 +26,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.tumblr(link)}
@@ -37,9 +38,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <TumblrIconFill />
+      <TumblrIconFill {...props} />
     ) : (
-      <Tumblr small={small}>
+      <Tumblr small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/twitter.js
+++ b/src/buttons/twitter.js
@@ -27,7 +27,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.twitter(message, link)}
@@ -37,9 +38,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <TwitterIconFill />
+      <TwitterIconFill {...props} />
     ) : (
-      <Twitter small={small}>
+      <Twitter small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/vk.js
+++ b/src/buttons/vk.js
@@ -27,7 +27,8 @@ const Button = ({
   circle,
   solidcircle,
   simple,
-  simpleReverse
+  simpleReverse,
+  ...props
 }) => (
   <Link
     href={links.vk(message, link)}
@@ -37,9 +38,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <VKIconFill />
+      <VKIconFill {...props} />
     ) : (
-      <VK small={small}>
+      <VK small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/whatsapp.js
+++ b/src/buttons/whatsapp.js
@@ -42,9 +42,9 @@ const Button = ({
     simpleReverse={simpleReverse}
   >
     {simple || simpleReverse ? (
-      <WhatsappIconFill />
+      <WhatsappIconFill {...props} />
     ) : (
-      <Whatsapp small={small}>
+      <Whatsapp small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}

--- a/src/buttons/xing.js
+++ b/src/buttons/xing.js
@@ -42,9 +42,9 @@ const Button = ({
     simple={simple}
   >
     {simple || simpleReverse ? (
-      <XingIconFill />
+      <XingIconFill {...props} />
     ) : (
-      <Xing small={small}>
+      <Xing small={small} {...props}>
         <Icon
           solid={(!solid && !circle && !solidcircle) || solid}
           solidcircle={solidcircle}


### PR DESCRIPTION
Hi,

I was trying to style. Just for make the icon bigger or change color.

Something link:

```jsx
import SocialSharing from 'react-social-sharing'

const Twitter = SocialSharing.Twitter.extend`
background: black;
`
```

Looks like currently is not possible because you are not passing `style`.

I added the ability to pass the props from the component interface.

![screen shot 2018-03-04 at 18 16 54](https://user-images.githubusercontent.com/2096101/36948247-40503eea-1fd8-11e8-8baf-a80a89bb630e.png)


The babel plugin is to be possible use `...props` syntax, that is clean way to pass the rest of props.

I could extend the documentation as well, but no idea catalog 🙂