### PR TITLE
Added missing message prop to Telegram component

### DIFF
--- a/src/buttons/telegram.js
+++ b/src/buttons/telegram.js
@@ -20,11 +20,11 @@ const Telegram = styled(SharingButton)`
   }
 `
 
-export default ({ link, name, ...props }) => (
+export default ({ link, name, message, ...props }) => (
   <ButtonFactory
     {...props}
     name={name || 'Telegram'}
-    href={links.telegram(link)}
+    href={links.telegram(link, message)}
     buttonComponent={Telegram}
     iconFill={TelegramIconFill}
     iconCircle={TelegramIconCircle}


### PR DESCRIPTION
Hello!
I have noticed that the Telegram share button missing the text. This change should fix it.